### PR TITLE
Status on compatibility with previous PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
 # https://phpunit.de/supported-versions.html
 matrix:
   include:
+  - php: 5.6
+    env: PHPUNIT_VERSION=5.7.*
+  - php: 7.0
+    env: PHPUNIT_VERSION=6.5.*
   - php: 7.1
     env: PHPUNIT_VERSION=7.5.*
   - php: 7.2


### PR DESCRIPTION
This pull request to check older PHP versions.

Verdict:
- should work with PHP 7.0
- *might* work with PHP 5.6 but tests are using PHP 7+ features so we can't know.
